### PR TITLE
Respect configuration files for actionlint

### DIFF
--- a/flymake-actionlint.el
+++ b/flymake-actionlint.el
@@ -102,9 +102,19 @@ See `flymake-err-line-patterns'.")
 (defvar flymake-actionlint-executable "actionlint"
   "Executable of `actionlint'.")
 
+(defun flymake-actionlint-config (filename)
+  "Return a list consists of -config-file flag and file path to the actionlint configuration."
+  (let* ((github-dir (file-name-parent-directory (file-name-parent-directory (flymake-get-real-file-name filename))))
+         (yaml (concat github-dir "actionlint.yaml"))
+         (yml (concat github-dir "actionlint.yml")))
+    (cond ((file-exists-p yaml) (list "-config-file" yaml))
+          ((file-exists-p yml) (list "-config-file" yml))
+          (t nil))))
+
 (defun flymake-actionlint-command (filename)
   "Return list command which run `actionlint' to FILENAME."
-  (list flymake-actionlint-executable "-oneline" "-no-color" filename))
+  (let ((config-file (flymake-actionlint-config filename)))
+    (append (list flymake-actionlint-executable "-oneline" "-no-color") config-file (list filename))))
 
 ;;;###autoload
 (defun flymake-actionlint-load ()


### PR DESCRIPTION
actionlint supports [some configurations](https://github.com/rhysd/actionlint/blob/main/docs/config.md) but for now, flymake-actionlint does not respect it.

By default, actionlint reads the configuration file without specifying via a command-line argument. However, this flymake-actionlint first copies the buffer content into a temporary where not in the project directory so actionlint cannot detect the configuration file.
This PR is to find configuration file and pass the path to actionlint as a command-line argument if one exists.